### PR TITLE
Added jms to the list of excluded libraries for log4j.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,10 @@
             <artifactId>jmxtools</artifactId>
             <groupId>com.sun.jdmk</groupId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.jms</groupId>
+            <artifactId>jms</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
I wasn't able to build it, because log4j in dkpro-bigdata-hadoop depended on javax.jms. Hence, I excluded it from the log4j configuration in the parent pom.xml.
